### PR TITLE
surfaceflinger: Allow ZOrder override for UDFPS dim layer

### DIFF
--- a/services/surfaceflinger/CompositionEngine/src/OutputLayer.cpp
+++ b/services/surfaceflinger/CompositionEngine/src/OutputLayer.cpp
@@ -467,6 +467,9 @@ void OutputLayer::writeOutputDependentGeometryStateToHWC(HWC2::Layer* hwcLayer,
                (strncmp(getLayerFE().getDebugName(), UDFPS_BIOMETRIC_PROMPT_LAYER_NAME,
                         strlen(UDFPS_BIOMETRIC_PROMPT_LAYER_NAME)) == 0)) {
         z_udfps = getUdfpsZOrder(z, false);
+    } else if (strncmp(getLayerFE().getDebugName(), UDFPS_DIM_LAYER_NAME,
+                       strlen(UDFPS_DIM_LAYER_NAME)) == 0) {
+        z_udfps = getUdfpsDimZOrder(z);
     } else if (strncmp(getLayerFE().getDebugName(), UDFPS_TOUCHED_LAYER_NAME,
                        strlen(UDFPS_TOUCHED_LAYER_NAME)) == 0) {
         z_udfps = getUdfpsZOrder(z, true);


### PR DESCRIPTION
Change-Id: I367b2c395aeb8cb7cb9e3cc38eca98477befe007